### PR TITLE
add 4 cards to show asset data and update layout of main content

### DIFF
--- a/jsProject/page1.html
+++ b/jsProject/page1.html
@@ -27,10 +27,11 @@
     }
 
     .container {
-      /* background-color: #2b66b832; */
+      /*background-color: #2b66b832;*/
       display: flex;
       width: 100%;
       height: 100%;
+
     }
 
     .sidebar-left {
@@ -60,6 +61,43 @@
       padding: 20px;
       overflow: auto;
       height: calc(100vh - 100px); /* Adjust height to account for header */
+      display: flex;
+      flex-direction: column;
+
+      /*display: grid;*/
+      /*grid-template-rows: 55% 45%; !* 图表和按钮占55%，卡片占45% *!*/
+      /*grid-template-areas:*/
+      /*  "chart"*/
+      /*  "cards";*/
+      /*gap: 20px;*/
+      /*padding: 20px;*/
+      /*overflow: hidden;*/
+    }
+    .main-content button {
+      margin: 20px ;
+    }
+    /* 确保图表容器不会溢出 */
+    .chart-responsive {
+      display: flex;
+      flex-direction: column;
+      width: 100%;
+      height: 350px; /* 固定高度 */
+      min-height: 200px;
+      max-height: 50vh;
+      margin-bottom: 20px;
+    }
+
+    /* 按钮容器独立布局 */
+    .chart-buttons {
+      text-align: center;
+      margin: 10px 0;
+      flex-shrink: 0; /* 防止按钮区域被压缩 */
+    }
+
+    /* 确保所有canvas有相同的布局规则 */
+    .chart-container canvas {
+      width: 100% !important;
+      height: 100% !important;
     }
 
     .sidebar-right {
@@ -97,8 +135,104 @@
     }
 
 
-    #chartContainer, #pieChartContainer, #historicalData {
-      margin-bottom: 20px;
+    /*#chartContainer, #pieChartContainer, #historicalData {*/
+    /*  margin-bottom: 20px;*/
+    /*}*/
+    .cards-container {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 25px;
+      width: 100%;
+      max-width: 1300px;
+      margin: 0 auto;
+    }
+
+    @media (max-width: 1024px) {
+      .cards-container {
+        grid-template-columns: repeat(2, 1fr);
+      }
+    }
+    @media (max-width: 600px) {
+      .cards-container {
+        grid-template-columns: 1fr;
+      }
+    }
+
+    .card {
+      background: white;
+      border-radius: 16px;
+      box-shadow: 0 10px 30px rgba(0, 0, 0, 0.05);
+      padding: 22px;
+      position: relative;
+      overflow: hidden;
+      transition: transform 0.3s ease, box-shadow 0.3s ease;
+    }
+    .card:hover {
+      transform: translateY(-5px);
+      box-shadow: 0 15px 40px rgba(0, 0, 0, 0.1);
+    }
+    .card-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 30px;
+    }
+    .card-title {
+      font-size: 1.1rem;
+      font-weight: 600;
+      color: #34495e;
+    }
+    .profit-indicator {
+      font-weight: 700;
+      font-size: 1.2rem;
+      padding: 3px 8px;
+      border-radius: 5px;
+    }
+    .loss {
+      color: #27ae60;
+      background-color: rgba(39, 174, 96, 0.15);
+    }
+    .profit {
+      color: #e74c3c;
+      background-color: rgba(231, 76, 60, 0.15);
+    }
+    .card-content {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+    }
+    .balance-large {
+      font-size: 2.1rem;
+      font-weight: 700;
+      margin-bottom: 5px;
+      letter-spacing: -0.5px;
+      color: #2c3e50;
+    }
+    .balance-small {
+      font-size: 1.1rem;
+      color: #7f8c8d;
+      font-weight: 500;
+    }
+    .card:nth-child(1) {
+      background-color: rgba(255, 178, 89, 0.15);
+      border-top: 4px solid #FFB259;
+    }
+    .card:nth-child(2) {
+      background-color: rgba(173, 126, 201, 0.15);
+      border-top: 4px solid #AD7EC9;
+    }
+    .card:nth-child(3) {
+      background-color: rgba(122, 141, 157, 0.15);
+      border-top: 4px solid #7A8D9D;
+    }
+    .card:nth-child(4) {
+      background-color: rgba(255, 155, 192, 0.15);
+      border-top: 4px solid #FF9BC0;
+    }
+    @media (max-width: 768px) {
+      .cards-container {
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      }
     }
   </style>
 </head>
@@ -127,20 +261,71 @@
 
     <!-- Main Content Area -->
     <div class="main-content">
-      
-      <div style="margin-bottom: 20px; text-align: center;">
-        <button id="dailyBtn">日</button>
-        <button id="weeklyBtn">周</button>
-        <button id="monthlyBtn">月</button>
+
+
+      <!-- change to 4 card -->
+<!--      <div id="historicalData">-->
+<!--        <canvas id="historyChart"></canvas>-->
+<!--      </div>-->
+      <!-- 资产卡片区 -->
+      <div class="cards-container">
+        <!-- 总资产卡片 -->
+        <div class="card">
+          <div class="card-header">
+            <h2 class="card-title">总资产</h2>
+            <div class="profit-indicator profit">+</div>
+          </div>
+          <div class="card-content">
+            <div class="balance-large">€2,14,595</div>
+            <div class="balance-small">$2,14,595</div>
+          </div>
+        </div>
+        <!-- 总盈亏卡片 -->
+        <div class="card">
+          <div class="card-header">
+            <h2 class="card-title">总盈亏</h2>
+            <div class="profit-indicator profit">+</div>
+          </div>
+          <div class="card-content">
+            <div class="balance-large">€2,14,595</div>
+            <div class="balance-small">$2,14,595</div>
+          </div>
+        </div>
+        <!-- 每日盈余卡片 -->
+        <div class="card">
+          <div class="card-header">
+            <h2 class="card-title">每日盈余</h2>
+            <div class="profit-indicator loss">-</div>
+          </div>
+          <div class="card-content">
+            <div class="balance-large">€2,14,595</div>
+            <div class="balance-small">$2,14,595</div>
+          </div>
+        </div>
+        <!-- 总市值卡片 -->
+        <div class="card">
+          <div class="card-header">
+            <h2 class="card-title">总市值</h2>
+            <div class="profit-indicator profit">+</div>
+          </div>
+          <div class="card-content">
+            <div class="balance-large">€2,14,595</div>
+            <div class="balance-small">+1.123%</div>
+          </div>
+        </div>
       </div>
-      <div id="chartContainer">
-        <canvas id="dailyChart"></canvas>
-      </div>
-      <!-- <div id="pieChartContainer">
-        <canvas id="pieChart"></canvas>
-      </div> -->
-      <div id="historicalData">
-        <canvas id="historyChart"></canvas>
+      <!-- 资产卡片区结束 -->
+      <div class="chart-responsive" style="display: flex; flex-direction: column; align-items: stretch; width: 100%; height: 350px; min-height: 200px; max-height: 50vh; margin-bottom: 20px;">
+        <div style="text-align: center; margin-bottom: 10px;">
+          <button id="dailyBtn">日</button>
+          <button id="weeklyBtn">周</button>
+          <button id="monthlyBtn">月</button>
+        </div>
+        <div style="flex: 1 1 0; position: relative; width: 100%; height: 100%;">
+          <canvas id="dailyChart" style="width:100%!important; height:100%!important; display:block;"></canvas>
+          <canvas id="weeklyChart" style="width:100%!important; height:100%!important; display:none;"></canvas>
+          <canvas id="monthlyChart" style="width:100%!important; height:100%!important; display:none;"></canvas>
+        </div>
       </div>
     </div>
 

--- a/jsProject/page1.js
+++ b/jsProject/page1.js
@@ -9,16 +9,19 @@ document.getElementById('monthlyBtn').addEventListener('click', () => switchChar
 let dailyChart, historyChart, pieChart;
 
 const stockData_daily = {
-  labels: ['2025-07-01', '2025-07-02', '2025-07-03', '2025-07-04', '2025-07-05'], // Example dates
-  data: [150, 155, 160, 158, 162] // Example stock prices
+  labels: ['2025-07-01', '2025-07-02', '2025-07-03', '2025-07-04', '2025-07-05'],
+  high:   [152.3, 157.8, 162.0, 160.5, 165.2], // 最高价
+  close:  [150.1, 155.0, 160.2, 158.3, 162.7]  // 收盘价
 };
 const stockData_weekly = {
-  labels: ['2025-06-01', '2025-06-08', '2025-06-15', '2025-06-22', '2025-07-05'], // Example dates
-  data: [150, 135, 169, 128, 152] // Example stock prices
+  labels: ['2025-06-01', '2025-06-08', '2025-06-15', '2025-06-22', '2025-07-05'],
+  high:   [155.0, 140.2, 172.5, 130.8, 155.6],
+  close:  [150.0, 135.5, 169.0, 128.0, 152.0]
 };
 const stockData_monthly = {
-  labels: ['2025-03-05', '2025-04-02', '2025-05-03', '2025-06-04', '2025-07-05'], // Example dates
-  data: [120, 155, 140, 138, 169] // Example stock prices
+  labels: ['2025-03-05', '2025-04-02', '2025-05-03', '2025-06-04', '2025-07-05'],
+  high:   [125.0, 160.0, 145.0, 142.0, 175.0],
+  close:  [120.0, 155.0, 140.0, 138.0, 169.0]
 };
 
 const cashData = {
@@ -31,59 +34,124 @@ const historicalData = {
   data: [1000, 1200, 1100, 1300, 1400]
 };
 
-function createDailyChart() {
-  const ctx = document.getElementById('dailyChart').getContext('2d');
-  dailyChart = new Chart(ctx, {
+// 历史资产走势数据（模拟）
+const assetHistoryData = {
+  labels: ['2025-01', '2025-02', '2025-03', '2025-04', '2025-05', '2025-06', '2025-07'],
+  values: [100000, 120000, 115000, 130000, 140000, 138000, 150000]
+};
+
+// 将时间类型转换为Chart实例的键
+function getChartKey(type) {
+  return `${type}ChartInstance`;
+}
+
+// 初始化所有图表容器
+function initChartContainers() {
+  const chartContainers = {
+    daily: document.getElementById('dailyChart'),
+    weekly: document.getElementById('weeklyChart'),
+    monthly: document.getElementById('monthlyChart')
+  };
+  
+  // 初始显示日线图
+  Object.keys(chartContainers).forEach(key => {
+    chartContainers[key].style.display = key === 'daily' ? 'block' : 'none';
+  });
+  
+  return chartContainers;
+}
+
+// 创建统一图表函数
+function createChart(type, data) {
+  const ctx = document.getElementById(`${type}Chart`).getContext('2d');
+  
+  return new Chart(ctx, {
     type: 'line',
     data: {
-      labels: stockData_daily.labels,
-      datasets: [{
-        label: 'Stock Price',
-        data: stockData_daily.data,
-        borderColor: 'blue',
-        backgroundColor: 'transparent',
-        fill: false,
-        tension: 0.1
-      }]
+      labels: data.labels,
+      datasets: [
+        {
+          label: '最高价',
+          data: data.high,
+          borderColor: 'grey',
+          backgroundColor: 'rgba(61,52,39,0.1)',
+          fill: false,
+          tension: 0.1
+        },
+        {
+          label: '收盘价',
+          data: data.close,
+          borderColor: 'blue',
+          backgroundColor: 'rgba(0,123,255,0.1)',
+          fill: false,
+          tension: 0.1
+        }
+      ]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      scales: {
+        y: {
+          beginAtZero: false,
+          grace: '10%'
+        }
+      },
+      plugins: {
+        legend: {
+          display: true,
+          position: 'top',
+        }
+      }
     }
   });
 }
 
-function createWeeklyChart() {
-  const ctx = document.getElementById('dailyChart').getContext('2d');
-  dailyChart = new Chart(ctx, {
-    type: 'line',
-    data: {
-      labels: stockData_weekly.labels,
-      datasets: [{
-        label: 'Stock Price',
-        data: stockData_weekly.data,
-        borderColor: 'blue',
-        backgroundColor: 'transparent',
-        fill: false,
-        tension: 0.1
-      }]
-    }
+// 图表切换函数（重写版）
+function switchChart(type) {
+  // 确保当前图表实例存在
+  if (!window.chartInstances) window.chartInstances = {};
+  
+  // 隐藏所有图表
+  const types = ['daily', 'weekly', 'monthly'];
+  types.forEach(t => {
+    const chartEl = document.getElementById(`${t}Chart`);
+    if (chartEl) chartEl.style.display = 'none';
   });
+  
+  // 显示当前图表
+  const currentChartEl = document.getElementById(`${type}Chart`);
+  if (currentChartEl) {
+    currentChartEl.style.display = 'block';
+    
+    // 获取当前图表实例键
+    const chartKey = getChartKey(type);
+    
+    // 如果图表尚未创建
+    if (!window.chartInstances[chartKey]) {
+      // 获取对应数据
+      const chartData = {
+        daily: stockData_daily,
+        weekly: stockData_weekly,
+        monthly: stockData_monthly
+      }[type];
+      
+      // 创建新图表
+      if (chartData) {
+        window.chartInstances[chartKey] = createChart(type, chartData);
+      }
+    }
+    
+    // 强制更新图表尺寸
+    setTimeout(() => {
+      if (window.chartInstances[chartKey]) {
+        window.chartInstances[chartKey].resize();
+        window.chartInstances[chartKey].update();
+      }
+    }, 50);
+  }
 }
 
-function createMonthlyChart() {
-  const ctx = document.getElementById('dailyChart').getContext('2d');
-  dailyChart = new Chart(ctx, {
-    type: 'line',
-    data: {
-      labels: stockData_monthly.labels,
-      datasets: [{
-        label: 'Stock Price',
-        data: stockData_monthly.data,
-        borderColor: 'blue',
-        backgroundColor: 'transparent',
-        fill: false,
-        tension: 0.1
-      }]
-    }
-  });
-}
 function createPieChart() {
   const ctx = document.getElementById('pieChart').getContext('2d');
   pieChart = new Chart(ctx, {
@@ -113,6 +181,31 @@ function createHistoryChart() {
   });
 }
 
+function createAssetHistoryChart() {
+  const ctx = document.getElementById('dailyChart').getContext('2d');
+  if (dailyChart) dailyChart.destroy();
+  dailyChart = new Chart(ctx, {
+    type: 'line',
+    data: {
+      labels: assetHistoryData.labels,
+      datasets: [
+        {
+          label: '历史资产走势',
+          data: assetHistoryData.values,
+          borderColor: 'green',
+          backgroundColor: 'rgba(39, 174, 96, 0.15)',
+          fill: true,
+          tension: 0.1
+        }
+      ]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false
+    }
+  });
+}
+
 function showStockData() {
   createDailyChart();
   createPieChart();
@@ -131,17 +224,17 @@ function showCashData() {
   // Implement the logic for cash data visualization
 }
 
-function switchChart(type) {
-  if (dailyChart) {
-    dailyChart.destroy();
-  }
-  if (type === 'daily') {
-    createDailyChart();
-  } else if (type === 'weekly') {
-    createWeeklyChart();
-  } else if (type === 'monthly') {
-    createMonthlyChart();
-  }
-}
+// DOM加载初始化
+document.addEventListener('DOMContentLoaded', function() {
+  // 初始化图表容器
+  initChartContainers();
+  
+  // 初始显示日线图
+  window.chartInstances = {};
+  window.chartInstances.dailyChartInstance = createChart('daily', stockData_daily);
+  
+  // 其他初始化代码
+  createPieChart();
+  createHistoryChart();
+});
 
-showStockData(); // Show stock data by default


### PR DESCRIPTION
Add 4 main cards to show asset data: 总资产（股票+基金+金价+现金），总盈亏（今日价格与买入价的比较），每日盈余（今日价格与上一日价格的比较）；总市值（股票+基金）

Update layout of maincard: 优化布局，解决main-containt宽度随linechart变化的问题。

待优化：
1. linechart 高度覆盖content
2. 点击4张cards 切换对应资产历史数据折线图